### PR TITLE
Reduce GIF Creation Time with Tailored Color Palette

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
     "context"
     "fmt"
     "image"
-    "image/color/palette"
+    "image/color"
     "image/draw"
     "image/gif"
     "image/png"
@@ -54,6 +54,36 @@ var boardSrc = map[byte][2]int{
     '\'': {5, 5}, '"': {5, 6}, '*': {5, 7}, ' ': {5, 8},
 }
 
+// From liwords/liwords-ui/src/color_modes.scss
+// color-board-dls: #b9e7f5,
+// color-board-dws: #f6c0c0,
+// color-board-tws: #a92e2e,
+// color-board-tls: #3b88ca,
+// color-board-empty: #ffffff,
+// color-tile-background: #6b268b,
+// color-tile-background-secondary: #cfb7d1,
+// color-tile-background-tertiary: #955f9a,
+// color-tile-background-quaternary: #dec5e4,
+// color-tile-blank-text: #6b268b,
+// color-tile-text: #ffffff,
+// color-tile-last-background: #f4b000,
+// color-tile-last-text: #414141,
+// color-tile-last-blank: #414141,
+
+var colorPalette = []color.Color{ 
+    color.RGBA{0xb9, 0xe7, 0xf5, 0xff}, 
+    color.RGBA{0xf6, 0xc0, 0x0c, 0xff},
+    color.RGBA{0xa9, 0x2e, 0x2e, 0xff},
+    color.RGBA{0x3b, 0x88, 0xca, 0xff},
+    color.RGBA{0xff, 0xff, 0xff, 0xff},
+    color.RGBA{0x6b, 0x26, 0x8b, 0xff},
+    color.RGBA{0xcf, 0xb7, 0xd1, 0xff},
+    color.RGBA{0x95, 0xf5, 0x9a, 0xff},
+    color.RGBA{0xde, 0xc5, 0xe4, 0xff},
+    color.RGBA{0x6b, 0x26, 0x8b, 0xff},
+    color.RGBA{0xf4, 0xb0, 0x00, 0xff},
+    color.RGBA{0x41, 0x41, 0x41, 0xff} }
+
 // Doubled because of retina screen.
 const squareDim = 2 * 34
 
@@ -78,7 +108,7 @@ func loadTilesImg() (image.Image, error) {
 
 func AnimateGame(tilesImg image.Image, boardConfig []string, hist *macondopb.GameHistory) (*gif.GIF, error) {
 
-    img := image.NewPaletted(image.Rect(0, 0, 15*squareDim, 15*squareDim), palette.Plan9)
+    img := image.NewPaletted(image.Rect(0, 0, 15*squareDim, 15*squareDim), colorPalette)
     gameGif := &gif.GIF{}
 
     // Draw the board.
@@ -100,7 +130,7 @@ func AnimateGame(tilesImg image.Image, boardConfig []string, hist *macondopb.Gam
 
     prevImg := img
     for i := range hist.Events {
-	evtImg := image.NewPaletted(prevImg.Bounds(), palette.Plan9)
+	evtImg := image.NewPaletted(prevImg.Bounds(), colorPalette)
         draw.Draw(evtImg, evtImg.Bounds(), prevImg, image.Pt(0, 0), draw.Over)
         removePhony, err := drawEvent(*hist.Events[i], evtImg, tilesImg)
         if err != nil {


### PR DESCRIPTION
Tailored the color palette to only the colors used for the board spaces and tiles on woogles. The chosen color palette anticipates the addition of different colors for each player.